### PR TITLE
fix: propagate UserID on ExecuteRequest in TriggerAgent and resume handlers

### DIFF
--- a/apps/server/domain/agents/handler.go
+++ b/apps/server/domain/agents/handler.go
@@ -695,6 +695,7 @@ func (h *Handler) TriggerAgent(c echo.Context) error {
 			ProjectID:       agent.ProjectID,
 			OrgID:           orgID,
 			UserMessage:     userMessage,
+			UserID:          user.ID, // propagate for ask_user notifications
 			TriggerMetadata: triggerReq.Context,
 			Model:           triggerReq.Model,
 			EnvVars:         triggerReq.EnvVars,
@@ -2581,6 +2582,7 @@ func (h *Handler) HandleRespondToQuestion(c echo.Context) error {
 				AgentDefinition: agentDef,
 				ProjectID:       agent.ProjectID,
 				UserMessage:     userMessage,
+				UserID:          user.ID, // propagate for ask_user notifications
 				AuthToken:       resumeAuthToken,
 			})
 			if result != nil && result.Cleanup != nil {


### PR DESCRIPTION
## Problem

The `ask_user` tool creates `AgentQuestion` records but never creates notifications or emits SSE events in certain trigger paths — specifically the REST `TriggerAgent` handler and the `HandleRespondToQuestion` resume handler.

This means the Diane Discord bot never receives `agent_question` events, and users don't see interactive buttons to respond to agent questions.

## Root Cause

The `ExecuteRequest` struct has a `UserID` field, and `buildAskUserTool` wires `req.UserID → deps.UserID`. But `createQuestionNotification` in `ask_user_tool.go` guards notification creation with `if deps.UserID == ""` — when `UserID` is empty, the notification is silently skipped.

Three handlers were missing `UserID` on their `ExecuteRequest`:
1. **`TriggerAgent`** (REST) — `user := auth.GetUser(c)` was available but not forwarded
2. **`HandleRespondToQuestion`** (resume) — `user := auth.GetUser(c)` was available but not forwarded
3. **`ReceiveWebhook`** — webhooks don't have an authenticated user context; skipped (UserID stays empty, which is correct for system-triggered webhooks)

## Changes

`apps/server/domain/agents/handler.go` — adds `UserID: user.ID` to `ExecuteRequest` in:
- `TriggerAgent` (line \~698)
- `HandleRespondToQuestion` (line \~2586)

## Related Work

Previous commit `af1d4cb3` fixed:
- ACP CreateRun handler
- ACP ResumeRun handler  
- Chat WebSocket handler (`streamAgentChat`)
- Added `UserID` field to `ExecuteRequest` struct
- Wired `req.UserID → deps.UserID` in `buildAskUserTool`

The `handler.go` changes from that commit were dropped during rebase against origin/main.

## How to Verify

1. Build and deploy this PR
2. Trigger any agent via `POST /api/projects/:id/agents/:id/trigger` with a prompt that calls `ask_user`
3. Run status should be `paused`
4. A notification of type `agent_question` should appear in `kb.notifications`
5. SSE event `entity.created` for entity `notification` should fire
6. Diane's SSE client should receive it and post a Discord embed with action buttons

## Summary by Sourcery

Propagate the authenticated user ID into agent execution requests so ask_user questions triggered via REST and resume handlers can generate notifications and SSE events.

Bug Fixes:
- Ensure TriggerAgent REST handler includes the authenticated user ID on ExecuteRequest for proper ask_user notification emission.
- Ensure HandleRespondToQuestion resume handler includes the authenticated user ID on ExecuteRequest so resumed runs can emit ask_user notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user identification in agent-generated notifications to ensure they are properly attributed and delivered to the correct user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->