### PR TITLE
fix: emit project-wide SSE events for ask_user regardless of UserID

### DIFF
--- a/apps/server/domain/agents/ask_user_tool.go
+++ b/apps/server/domain/agents/ask_user_tool.go
@@ -103,20 +103,27 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 				slog.Int("options_count", len(options)),
 			)
 
-			// Create a notification for the user
+			// Create a notification for the user (requires valid UserID).
+			// For API-token-triggered runs UserID may be empty — skip the DB notification
+			// but still emit the SSE event so connected clients (Discord bot) receive it.
+			var notifID string
 			if deps.UserID != "" {
-				notificationID := createQuestionNotification(ctx, deps, q)
-				if notificationID != "" {
-					// Link notification to question
-					if err := deps.Repo.UpdateQuestionNotificationID(ctx, q.ID, notificationID); err != nil {
-						deps.Logger.Warn("failed to link notification to question",
-							slog.String("question_id", q.ID),
-							slog.String("notification_id", notificationID),
-							slog.String("error", err.Error()),
-						)
-					}
+				notifID = createQuestionNotification(ctx, deps, q)
+			}
+			if notifID != "" {
+				// Link notification to question
+				if err := deps.Repo.UpdateQuestionNotificationID(ctx, q.ID, notifID); err != nil {
+					deps.Logger.Warn("failed to link notification to question",
+						slog.String("question_id", q.ID),
+						slog.String("notification_id", notifID),
+						slog.String("error", err.Error()),
+					)
 				}
 			}
+
+			// Always emit the SSE event so connected clients (Discord bot, admin UI)
+			// receive the question in real-time, even without a DB notification.
+			emitQuestionSSEEvent(ctx, deps, q)
 
 			// Signal the executor to pause on the next beforeModelCb
 			deps.PauseState.RequestPause(q.ID)
@@ -187,25 +194,33 @@ func createQuestionNotification(ctx tool.Context, deps AskUserToolDeps, q *Agent
 		slog.String("notification_id", notifID),
 	)
 
-	// Emit real-time SSE event so connected clients (Diane bot, admin UI) are notified instantly.
-	if deps.EventsSvc != nil {
-		deps.EventsSvc.EmitCreated(
-			events.EntityNotification,
-			notifID,
-			deps.ProjectID,
-			&events.EmitOptions{
-				Data: map[string]any{
-					"type":        "agent_question",
-					"question_id": q.ID,
-					"run_id":      q.RunID,
-					"question":    q.Question,
-					"status":      "pending",
-				},
-			},
-		)
-	}
+	// NOTE: SSE event is emitted unconditionally by the caller (emitQuestionSSEEvent).
+	// No need to emit it here as well — that would create duplicates.
 
 	return notifID
+}
+
+// emitQuestionSSEEvent sends a real-time SSE notification for a question.
+// This runs unconditionally so connected clients (Discord bot, admin UI) receive
+// the question even when no DB notification was created (e.g. API-token-triggered runs).
+func emitQuestionSSEEvent(ctx tool.Context, deps AskUserToolDeps, q *AgentQuestion) {
+	if deps.EventsSvc == nil {
+		return
+	}
+	deps.EventsSvc.EmitCreated(
+		events.EntityNotification,
+		q.ID, // use question ID as entity ID since there may be no notification
+		deps.ProjectID,
+		&events.EmitOptions{
+			Data: map[string]any{
+				"type":        "agent_question",
+				"question_id": q.ID,
+				"run_id":      q.RunID,
+				"question":    q.Question,
+				"status":      "pending",
+			},
+		},
+	)
 }
 
 // parseQuestionOptions extracts the options array from tool call args.


### PR DESCRIPTION
## Problem

The `ask_user` tool only emitted SSE events when a DB notification was created, which was gated on `deps.UserID != ""`. This meant API-token-authenticated runs — including cron triggers and Discord-bot-spawned agents — never sent real-time notifications to connected clients (Discord bot, admin UI).

**Root cause**: API tokens have `user_id = NULL` in the `api_tokens` table (lines 530-538 of `pkg/auth/middleware.go`), resulting in `AuthUser.ID` being empty.

## Solution

1. **Extracted** SSE emission from `createQuestionNotification` into a standalone `emitQuestionSSEEvent()` function
2. **Moved** the SSE call outside the `UserID != ""` guard so it always fires
3. **Removed** duplicate SSE emission from inside `createQuestionNotification`
4. DB notification still requires UserID (for admin UI); SSE event uses question ID as entity ID

## Why safe

Connected clients filter by **project**, not by user. A project-wide SSE event reaches all subscribers equally.

## Summary by Sourcery

Ensure ask_user tool emits project-wide SSE events for agent questions regardless of associated user ID, while keeping DB notifications conditional on having a user.

Bug Fixes:
- Fix missing real-time SSE notifications for ask_user questions triggered without a user ID (e.g. API token or bot runs).

Enhancements:
- Extract SSE emission for agent questions into a dedicated helper and decouple it from DB notification creation to avoid duplicates.