### PR TITLE
feat: add interaction_type, placeholder, max_length to ask_user tool

### DIFF
--- a/apps/server/domain/agents/ask_user_tool.go
+++ b/apps/server/domain/agents/ask_user_tool.go
@@ -81,12 +81,38 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 				switch AgentQuestionInteractionType(interactionTypeStr) {
 				case QuestionInteractionButtons, QuestionInteractionSelect, QuestionInteractionMultiSelect, QuestionInteractionText:
 					interactionType = AgentQuestionInteractionType(interactionTypeStr)
+				default:
+					deps.Logger.Warn("ask_user: unsupported interaction_type, defaulting to buttons",
+						slog.String("interaction_type", interactionTypeStr),
+					)
 				}
 			}
 
 			// Parse placeholder and max_length (for text interaction type)
 			placeholder, _ := args["placeholder"].(string)
-			maxLength, _ := args["max_length"].(float64)
+			var maxLength int
+			if raw, ok := args["max_length"]; ok {
+				switch v := raw.(type) {
+				case float64:
+					maxLength = int(v)
+				case int:
+					maxLength = v
+				case int64:
+					maxLength = int(v)
+				case json.Number:
+					if n, err := v.Int64(); err == nil {
+						maxLength = int(n)
+					} else {
+						deps.Logger.Warn("ask_user: invalid json.Number max_length, ignoring", slog.Any("max_length", raw))
+					}
+				default:
+					deps.Logger.Warn("ask_user: unsupported max_length type, ignoring", slog.Any("max_length", raw))
+				}
+				if maxLength < 0 {
+					deps.Logger.Warn("ask_user: negative max_length is invalid, ignoring", slog.Int("max_length", maxLength))
+					maxLength = 0
+				}
+			}
 
 			// Cancel any existing pending questions for this run
 			if err := deps.Repo.CancelPendingQuestionsForRun(ctx, deps.RunID); err != nil {
@@ -105,7 +131,7 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 				Options:         options,
 				InteractionType: interactionType,
 				Placeholder:     placeholder,
-				MaxLength:       int(maxLength),
+				MaxLength:       maxLength,
 				Status:          QuestionStatusPending,
 			}
 

--- a/apps/server/domain/agents/ask_user_tool.go
+++ b/apps/server/domain/agents/ask_user_tool.go
@@ -62,7 +62,7 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 	return functiontool.New(
 		functiontool.Config{
 			Name:        ToolNameAskUser,
-			Description: "Ask the user a question and pause execution until they respond. Use this when you encounter ambiguity, need clarification, or require a decision from the user. You can provide structured options for the user to choose from, or leave options empty for a free-text response. After calling this tool, execution will pause and resume automatically when the user responds.",
+			Description: "Ask the user a question and pause execution until they respond. Use this when you encounter ambiguity, need clarification, or require a decision from the user. You can provide structured options for the user to choose from, or leave options empty for a free-text response. Set interaction_type to 'buttons' (default, 2-5 options), 'select' (5+ options), 'multi_select' (multi-pick dropdown), or 'text' (free-text input with optional placeholder and max_length). After calling this tool, execution will pause and resume automatically when the user responds.",
 		},
 		func(ctx tool.Context, args map[string]any) (map[string]any, error) {
 			// Parse question (required)
@@ -74,6 +74,20 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 			// Parse options (optional array of {label, value})
 			options := parseQuestionOptions(args)
 
+			// Parse interaction_type (optional, defaults to "buttons")
+			interactionTypeStr, _ := args["interaction_type"].(string)
+			interactionType := QuestionInteractionButtons
+			if interactionTypeStr != "" {
+				switch AgentQuestionInteractionType(interactionTypeStr) {
+				case QuestionInteractionButtons, QuestionInteractionSelect, QuestionInteractionMultiSelect, QuestionInteractionText:
+					interactionType = AgentQuestionInteractionType(interactionTypeStr)
+				}
+			}
+
+			// Parse placeholder and max_length (for text interaction type)
+			placeholder, _ := args["placeholder"].(string)
+			maxLength, _ := args["max_length"].(float64)
+
 			// Cancel any existing pending questions for this run
 			if err := deps.Repo.CancelPendingQuestionsForRun(ctx, deps.RunID); err != nil {
 				deps.Logger.Warn("failed to cancel prior pending questions",
@@ -84,12 +98,15 @@ func BuildAskUserTool(deps AskUserToolDeps) (tool.Tool, error) {
 
 			// Create the question record
 			q := &AgentQuestion{
-				RunID:     deps.RunID,
-				AgentID:   deps.AgentID,
-				ProjectID: deps.ProjectID,
-				Question:  question,
-				Options:   options,
-				Status:    QuestionStatusPending,
+				RunID:           deps.RunID,
+				AgentID:         deps.AgentID,
+				ProjectID:       deps.ProjectID,
+				Question:        question,
+				Options:         options,
+				InteractionType: interactionType,
+				Placeholder:     placeholder,
+				MaxLength:       int(maxLength),
+				Status:          QuestionStatusPending,
 			}
 
 			if err := deps.Repo.CreateQuestion(ctx, q); err != nil {
@@ -213,11 +230,15 @@ func emitQuestionSSEEvent(ctx tool.Context, deps AskUserToolDeps, q *AgentQuesti
 		deps.ProjectID,
 		&events.EmitOptions{
 			Data: map[string]any{
-				"type":        "agent_question",
-				"question_id": q.ID,
-				"run_id":      q.RunID,
-				"question":    q.Question,
-				"status":      "pending",
+				"type":             "agent_question",
+				"question_id":      q.ID,
+				"run_id":           q.RunID,
+				"question":         q.Question,
+				"options":          q.Options,
+				"interaction_type": q.InteractionType,
+				"placeholder":      q.Placeholder,
+				"max_length":       q.MaxLength,
+				"status":           "pending",
 			},
 		},
 	)

--- a/apps/server/domain/agents/dto.go
+++ b/apps/server/domain/agents/dto.go
@@ -524,39 +524,45 @@ type WebhookTriggerPayloadDTO struct {
 
 // --- Agent Question DTOs ---
 
-// AgentQuestionDTO is the response DTO for an agent question.
+// AgentQuestionDTO is the API response format for an agent question.
 type AgentQuestionDTO struct {
-	ID             string                `json:"id"`
-	RunID          string                `json:"runId"`
-	AgentID        string                `json:"agentId"`
-	ProjectID      string                `json:"projectId"`
-	Question       string                `json:"question"`
-	Options        []AgentQuestionOption `json:"options"`
-	Response       *string               `json:"response,omitempty"`
-	RespondedBy    *string               `json:"respondedBy,omitempty"`
-	RespondedAt    *time.Time            `json:"respondedAt,omitempty"`
-	Status         AgentQuestionStatus   `json:"status"`
-	NotificationID *string               `json:"notificationId,omitempty"`
-	CreatedAt      time.Time             `json:"createdAt"`
-	UpdatedAt      time.Time             `json:"updatedAt"`
+	ID              string                         `json:"id"`
+	RunID           string                         `json:"runId"`
+	AgentID         string                         `json:"agentId"`
+	ProjectID       string                         `json:"projectId"`
+	Question        string                         `json:"question"`
+	Options         []AgentQuestionOption          `json:"options"`
+	InteractionType AgentQuestionInteractionType   `json:"interactionType"`
+	Placeholder     string                         `json:"placeholder,omitempty"`
+	MaxLength       int                            `json:"maxLength,omitempty"`
+	Response        *string                        `json:"response,omitempty"`
+	RespondedBy     *string                        `json:"respondedBy,omitempty"`
+	RespondedAt     *time.Time                     `json:"respondedAt,omitempty"`
+	Status          AgentQuestionStatus            `json:"status"`
+	NotificationID  *string                        `json:"notificationId,omitempty"`
+	CreatedAt       time.Time                      `json:"createdAt"`
+	UpdatedAt       time.Time                      `json:"updatedAt"`
 }
 
 // ToDTO converts an AgentQuestion entity to a DTO.
 func (q *AgentQuestion) ToDTO() *AgentQuestionDTO {
 	return &AgentQuestionDTO{
-		ID:             q.ID,
-		RunID:          q.RunID,
-		AgentID:        q.AgentID,
-		ProjectID:      q.ProjectID,
-		Question:       q.Question,
-		Options:        q.Options,
-		Response:       q.Response,
-		RespondedBy:    q.RespondedBy,
-		RespondedAt:    q.RespondedAt,
-		Status:         q.Status,
-		NotificationID: q.NotificationID,
-		CreatedAt:      q.CreatedAt,
-		UpdatedAt:      q.UpdatedAt,
+		ID:              q.ID,
+		RunID:           q.RunID,
+		AgentID:         q.AgentID,
+		ProjectID:       q.ProjectID,
+		Question:        q.Question,
+		Options:         q.Options,
+		InteractionType: q.InteractionType,
+		Placeholder:     q.Placeholder,
+		MaxLength:       q.MaxLength,
+		Response:        q.Response,
+		RespondedBy:     q.RespondedBy,
+		RespondedAt:     q.RespondedAt,
+		Status:          q.Status,
+		NotificationID:  q.NotificationID,
+		CreatedAt:       q.CreatedAt,
+		UpdatedAt:       q.UpdatedAt,
 	}
 }
 

--- a/apps/server/domain/agents/entity.go
+++ b/apps/server/domain/agents/entity.go
@@ -377,7 +377,21 @@ const (
 	QuestionStatusCancelled AgentQuestionStatus = "cancelled"
 )
 
-// AgentQuestionOption represents a structured choice option for a question
+// AgentQuestionInteractionType defines how a question should be rendered on the client.
+type AgentQuestionInteractionType string
+
+const (
+	// QuestionInteractionButtons presents options as clickable buttons (default for 2-5 options).
+	QuestionInteractionButtons    AgentQuestionInteractionType = "buttons"
+	// QuestionInteractionSelect presents options as a dropdown menu (for 5+ options).
+	QuestionInteractionSelect     AgentQuestionInteractionType = "select"
+	// QuestionInteractionMultiSelect presents options as a multi-select dropdown.
+	QuestionInteractionMultiSelect AgentQuestionInteractionType = "multi_select"
+	// QuestionInteractionText opens a free-text input modal (no options needed).
+	QuestionInteractionText       AgentQuestionInteractionType = "text"
+)
+
+// AgentQuestionOption represents a single option in an ask_user question.
 type AgentQuestionOption struct {
 	Label       string `json:"label"`
 	Value       string `json:"value"`
@@ -389,13 +403,16 @@ type AgentQuestionOption struct {
 type AgentQuestion struct {
 	bun.BaseModel `bun:"table:kb.agent_questions,alias:aq"`
 
-	ID             string                `bun:"id,pk,type:uuid,default:gen_random_uuid()" json:"id"`
-	RunID          string                `bun:"run_id,type:uuid,notnull" json:"runId"`
-	AgentID        string                `bun:"agent_id,type:uuid,notnull" json:"agentId"`
-	ProjectID      string                `bun:"project_id,type:uuid,notnull" json:"projectId"`
-	Question       string                `bun:"question,notnull" json:"question"`
-	Options        []AgentQuestionOption `bun:"options,type:jsonb,notnull,default:'[]'" json:"options"`
-	Response       *string               `bun:"response" json:"response,omitempty"`
+	ID             string                         `bun:"id,pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	RunID          string                         `bun:"run_id,type:uuid,notnull" json:"runId"`
+	AgentID        string                         `bun:"agent_id,type:uuid,notnull" json:"agentId"`
+	ProjectID      string                         `bun:"project_id,type:uuid,notnull" json:"projectId"`
+	Question       string                         `bun:"question,notnull" json:"question"`
+	Options        []AgentQuestionOption          `bun:"options,type:jsonb,notnull,default:'[]'" json:"options"`
+	InteractionType AgentQuestionInteractionType  `bun:"interaction_type,type:text,notnull,default:'buttons'" json:"interactionType"`
+	Placeholder    string                         `bun:"placeholder,type:text" json:"placeholder,omitempty"`
+	MaxLength      int                            `bun:"max_length" json:"maxLength,omitempty"`
+	Response       *string                        `bun:"response" json:"response,omitempty"`
 	RespondedBy    *string               `bun:"responded_by,type:uuid" json:"respondedBy,omitempty"`
 	RespondedAt    *time.Time            `bun:"responded_at" json:"respondedAt,omitempty"`
 	Status         AgentQuestionStatus   `bun:"status,notnull,default:'pending'" json:"status"`

--- a/apps/server/migrations/00099_add_agent_question_interaction_fields.sql
+++ b/apps/server/migrations/00099_add_agent_question_interaction_fields.sql
@@ -1,5 +1,12 @@
+-- +goose Up
 -- Add interaction_type, placeholder, and max_length columns to kb.agent_questions
 ALTER TABLE kb.agent_questions
   ADD COLUMN IF NOT EXISTS interaction_type text NOT NULL DEFAULT 'buttons',
   ADD COLUMN IF NOT EXISTS placeholder text,
   ADD COLUMN IF NOT EXISTS max_length integer;
+
+-- +goose Down
+ALTER TABLE kb.agent_questions
+  DROP COLUMN IF EXISTS interaction_type,
+  DROP COLUMN IF EXISTS placeholder,
+  DROP COLUMN IF EXISTS max_length;

--- a/apps/server/migrations/00099_add_agent_question_interaction_fields.sql
+++ b/apps/server/migrations/00099_add_agent_question_interaction_fields.sql
@@ -1,0 +1,5 @@
+-- Add interaction_type, placeholder, and max_length columns to kb.agent_questions
+ALTER TABLE kb.agent_questions
+  ADD COLUMN IF NOT EXISTS interaction_type text NOT NULL DEFAULT 'buttons',
+  ADD COLUMN IF NOT EXISTS placeholder text,
+  ADD COLUMN IF NOT EXISTS max_length integer;


### PR DESCRIPTION
## What

Extends the `ask_user` tool with an `interaction_type` parameter that controls how questions are rendered on clients (Discord, admin UI).

## New Parameters

| Parameter | Type | Default | Description |
|---|---|---|---|
| `interaction_type` | string | `"buttons"` | `"buttons"`, `"select"`, `"multi_select"`, `"text"` |
| `placeholder` | string | "" | Placeholder text for text input mode |
| `max_length` | int | 0 | Max input length for text mode |

## Client Rendering

| interaction_type | Rendering | Use Case |
|---|---|---|
| `buttons` (default) | One button per option | 2-5 clear choices |
| `select` | Dropdown menu | 5+ options |
| `multi_select` | Multi-select dropdown | Pick all that apply |
| `text` | Modal/input | Free-text response |

## Server Changes

- **`entity.go`**: New `AgentQuestionInteractionType` type + constants. New fields on `AgentQuestion`: `InteractionType`, `Placeholder`, `MaxLength`
- **`ask_user_tool.go`**: Parses new params from tool call args. Sets them on the entity. Includes all fields in SSE event payload (options array included too)
- **`dto.go`**: New fields on DTO and `ToDTO()`
- **Migration**: `00099` — adds columns to `kb.agent_questions`

This is the server-side foundation. The Diane Discord bot will be updated separately to use these fields for dynamic rendering.

## Summary by Sourcery

Extend agent questions and the ask_user tool to support configurable interaction types and text-input metadata for richer client rendering.

New Features:
- Add interaction_type, placeholder, and maxLength fields to agent question entities and API DTOs to control how questions are rendered on clients.
- Emit agent question SSE events with options and new interaction metadata so frontends can render appropriate UI components.
- Extend the ask_user tool interface and description to accept interaction_type, placeholder, and max_length arguments when creating questions.

Enhancements:
- Define AgentQuestionInteractionType constants to standardize supported interaction modes across the codebase.

Deployment:
- Add a database migration to store interaction_type, placeholder, and max_length on kb.agent_questions.