### PR TITLE
fix: capture DeepSeek reasoning_content as ADK Thought part for roundtrip

### DIFF
--- a/apps/server/pkg/adk/openai_model.go
+++ b/apps/server/pkg/adk/openai_model.go
@@ -309,6 +309,15 @@ func (m *openaiCompatibleModel) GenerateContent(ctx context.Context, req *model.
 		choice := result.Choices[0]
 		var parts []*genai.Part
 
+		// Emit reasoning content (DeepSeek thinking tokens) as a Thought part
+		// so it's stored in the ADK content and echoed back in subsequent requests.
+		if choice.Message.ReasoningContent != "" {
+			parts = append(parts, &genai.Part{
+				Text:    choice.Message.ReasoningContent,
+				Thought: true,
+			})
+		}
+
 		// Emit text content when present.
 		if choice.Message.Content != "" {
 			parts = append(parts, &genai.Part{Text: choice.Message.Content})

--- a/apps/server/pkg/adk/openai_model.go
+++ b/apps/server/pkg/adk/openai_model.go
@@ -47,11 +47,12 @@ func (m *openaiCompatibleModel) Name() string {
 // --- OpenAI wire types ---
 
 type openaiMessage struct {
-	Role       string           `json:"role"`
-	Content    string           `json:"content,omitempty"`
-	ToolCallID string           `json:"tool_call_id,omitempty"`
-	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
-	Name       string           `json:"name,omitempty"`
+	Role             string           `json:"role"`
+	Content          string           `json:"content,omitempty"`
+	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	ToolCallID       string           `json:"tool_call_id,omitempty"`
+	ToolCalls        []openaiToolCall `json:"tool_calls,omitempty"`
+	Name             string           `json:"name,omitempty"`
 }
 
 type openaiToolCall struct {
@@ -91,8 +92,9 @@ type responseFormat struct {
 type openaiResponse struct {
 	Choices []struct {
 		Message struct {
-			Content   string           `json:"content"`
-			ToolCalls []openaiToolCall `json:"tool_calls"`
+			Content          string           `json:"content"`
+			ToolCalls        []openaiToolCall `json:"tool_calls"`
+			ReasoningContent string           `json:"reasoning_content"`
 		} `json:"message"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
@@ -154,6 +156,7 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 
 		// Collect text parts and function calls/responses separately.
 		var textParts []string
+		var reasoningParts []string
 		var funcCalls []openaiToolCall
 		var funcResponses []struct {
 			id   string
@@ -165,7 +168,10 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			if part == nil {
 				continue
 			}
-			if part.Text != "" {
+			if part.Thought && part.Text != "" {
+				// Thought parts are DeepSeek reasoning_content — echo back separately.
+				reasoningParts = append(reasoningParts, part.Text)
+			} else if part.Text != "" {
 				textParts = append(textParts, part.Text)
 			}
 			if part.FunctionCall != nil {
@@ -207,6 +213,9 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			if len(textParts) > 0 {
 				msg.Content = strings.Join(textParts, "\n")
 			}
+			if len(reasoningParts) > 0 {
+				msg.ReasoningContent = strings.Join(reasoningParts, "\n")
+			}
 			messages = append(messages, msg)
 			continue
 		}
@@ -225,12 +234,18 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			continue
 		}
 
-		// Plain text message.
-		if len(textParts) > 0 {
-			messages = append(messages, openaiMessage{
-				Role:    role,
-				Content: strings.Join(textParts, "\n"),
-			})
+		// Plain text message (assistant with reasoning, or user/system).
+		if len(textParts) > 0 || len(reasoningParts) > 0 {
+			msg := openaiMessage{
+				Role: role,
+			}
+			if len(textParts) > 0 {
+				msg.Content = strings.Join(textParts, "\n")
+			}
+			if role == "assistant" && len(reasoningParts) > 0 {
+				msg.ReasoningContent = strings.Join(reasoningParts, "\n")
+			}
+			messages = append(messages, msg)
 		}
 	}
 	return messages


### PR DESCRIPTION
## Problem

DeepSeek's API returns `reasoning_content` (thinking tokens) in chat completion responses for `deepseek-v4-flash` and `deepseek-reasoner` models. On subsequent requests, it requires `reasoning_content` to be echoed back in assistant messages — rejecting the request with:

> `The reasoning_content in the thinking mode must be passed back to the API.`

The response handler silently dropped `reasoning_content` — it only extracted `Content` and `ToolCalls`. So the next request had no `reasoning_content`, and DeepSeek rejected it.

## Fix

Capture `reasoning_content` from the response as a `genai.Part` with `Thought=true`. The ADK history naturally stores this, and `buildMessages` already handles Thought parts — it sets `msg.ReasoningContent` when echoing them back to the API.

## Changes

`pkg/adk/openai_model.go`: +9 lines in `GenerateContent` — emit `ReasoningContent` as a Thought part before the text content part.

## Summary by Sourcery

Bug Fixes:
- Capture DeepSeek reasoning_content from responses as a Thought part so it is stored in history and echoed back to the API, preventing request rejections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where AI reasoning content in responses was being discarded. When AI models provide reasoning or thinking content as part of their output, this is now properly captured and included in the final response payload alongside standard response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->