### PR TITLE
fix: MCP schema tool column names to match actual DB schema

### DIFF
--- a/apps/server/domain/mcp/schema_tools.go
+++ b/apps/server/domain/mcp/schema_tools.go
@@ -164,7 +164,7 @@ func (s *Service) executeListSchemas(ctx context.Context, projectID string, args
 	}
 
 	if !includeDeprecated {
-		query = query.Where("deprecated = false")
+		query = query.Where("deprecated_at IS NULL")
 	}
 
 	query = query.Order("updated_at DESC").Limit(limit).Offset(offset)
@@ -202,7 +202,7 @@ func (s *Service) executeListSchemas(ctx context.Context, projectID string, args
 		countQuery = countQuery.Where("name ILIKE ? OR description ILIKE ?", "%"+search+"%", "%"+search+"%")
 	}
 	if !includeDeprecated {
-		countQuery = countQuery.Where("deprecated = false")
+		countQuery = countQuery.Where("deprecated_at IS NULL")
 	}
 	err = countQuery.Scan(ctx, &total)
 	if err != nil {
@@ -230,7 +230,7 @@ func (s *Service) executeGetSchema(ctx context.Context, projectID string, args m
 
 	var schema SchemaInfo
 	err := s.db.NewRaw(`
-		SELECT id, name, version, description, visibility, project_id, org_id, source, created_at, updated_at, deprecated
+		SELECT id, name, version, description, visibility, project_id, org_id, source, created_at, updated_at
 		FROM kb.graph_schemas
 		WHERE id = ? AND (project_id = ? OR (org_id = ? AND visibility = 'organization'))
 	`, schemaID, projectID, orgID).Scan(ctx, &schema)
@@ -241,7 +241,7 @@ func (s *Service) executeGetSchema(ctx context.Context, projectID string, args m
 	// Get object types
 	type objectTypeRow struct {
 		TypeName      string         `bun:"type_name"`
-		TypeSchema    map[string]any `bun:"type_schema,type:jsonb"`
+		TypeSchema    map[string]any `bun:"json_schema,type:jsonb"`
 		SchemaID      string         `bun:"schema_id"`
 		SchemaName    string         `bun:"schema_name"`
 		SchemaVersion string         `bun:"schema_version"`
@@ -254,7 +254,7 @@ func (s *Service) executeGetSchema(ctx context.Context, projectID string, args m
 		}
 
 		return tx.NewRaw(`
-			SELECT por.type_name, por.type_schema, por.schema_id, gs.name AS schema_name, gs.version AS schema_version
+			SELECT por.type_name, por.json_schema, por.schema_id, gs.name AS schema_name, gs.version AS schema_version
 			FROM kb.project_object_schema_registry por
 			JOIN kb.project_schemas ps ON por.schema_id = ps.schema_id AND ps.project_id = por.project_id
 			JOIN kb.graph_schemas gs ON por.schema_id = gs.id
@@ -369,7 +369,7 @@ func (s *Service) executeGetAvailableTemplates(ctx context.Context, projectID st
 	}
 
 	query = query.Where("source = 'template'").
-		Where("deprecated = false").
+		Where("deprecated_at IS NULL").
 		Order("created_at DESC").
 		Limit(limit)
 
@@ -389,7 +389,7 @@ func (s *Service) executeGetAvailableTemplates(ctx context.Context, projectID st
 	err = s.db.NewRaw(`
 		SELECT id, name, version, categories
 		FROM kb.graph_schemas
-		WHERE source = 'template' AND deprecated = false
+		WHERE source = 'template' AND deprecated_at IS NULL
 		ORDER BY created_at DESC
 		LIMIT 100
 	`).Scan(ctx, &templateRows)
@@ -1132,7 +1132,7 @@ func (s *Service) executeSchemaCompiledTypes(ctx context.Context, projectID stri
 
 	type objectTypeRow struct {
 		TypeName      string         `bun:"type_name"`
-		TypeSchema    map[string]any `bun:"type_schema,type:jsonb"`
+		TypeSchema    map[string]any `bun:"json_schema,type:jsonb"`
 		SchemaID      string         `bun:"schema_id"`
 		SchemaName    string         `bun:"schema_name"`
 		SchemaVersion string         `bun:"schema_version"`
@@ -1156,7 +1156,7 @@ func (s *Service) executeSchemaCompiledTypes(ctx context.Context, projectID stri
 		if err := tx.NewRaw(`
 			SELECT
 				por.type_name,
-				por.type_schema,
+				por.json_schema,
 				por.schema_id,
 				gs.name  AS schema_name,
 				gs.version AS schema_version


### PR DESCRIPTION
## Problem

Two MCP tools in `schema_tools.go` reference column names that don't exist in the production Postgres database, causing SQL `ERROR: column does not exist (SQLSTATE 42703)`:

### 1. `schema-list` — `column "deprecated" does not exist`

The code filters on `deprecated = false`, but `kb.graph_schemas` has `deprecated_at` (a `timestamp with time zone`), not a boolean `deprecated`. Affected in:
- `executeListSchemas` (2x — main query + count query)
- `executeGetAvailableTemplates` (2x — Bun query + raw SQL)
- `executeGetSchema` (1x — SELECT list)

### 2. `schema-compiled-types` and `schema-get` — `column por.type_schema does not exist`

The code queries `por.type_schema` from `kb.project_object_schema_registry`, but the actual column is `json_schema` (a `jsonb`). Affected in:
- `executeGetSchema` (struct tag + raw SQL)
- `executeSchemaCompiledTypes` (struct tag + raw SQL)

## Fix

Changed all 9 references across `schema_tools.go`:
- `deprecated = false` → `deprecated_at IS NULL` (5 occurrences)
- Removed `deprecated` from `executeGetSchema` SELECT (no struct field to capture it)
- `por.type_schema` → `por.json_schema` (2 occurrences in raw SQL)
- `bun:"type_schema,type:jsonb"` → `bun:"json_schema,type:jsonb"` (2 struct tags)

## Testing

These changes touch only column name string literals and Bun struct tags — no logic changes. Verify by running:
- Integration tests that exercise `schema-list` and `schema-compiled-types`
- Manual testing against a live project

Closes #<!-- will auto-resolve when merged -->

## Summary by Sourcery

Align MCP schema tools with the actual Postgres schema to prevent runtime column-not-found errors.

Bug Fixes:
- Update schema listing and template queries to filter using deprecated_at IS NULL instead of a non-existent deprecated column.
- Stop selecting the deprecated column from kb.graph_schemas in schema retrieval to match the real table definition.
- Use json_schema instead of the non-existent type_schema column in project_object_schema_registry queries and Bun mappings for schema types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced schema handling by improving deprecation detection logic and standardizing data retrieval methods across all schema operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->