### PR TITLE
feat: session lifecycle pruning — daily cleanup of old ADK session data

### DIFF
--- a/apps/server/domain/scheduler/config.go
+++ b/apps/server/domain/scheduler/config.go
@@ -46,6 +46,14 @@ type Config struct {
 	// ZitadelProfileSyncSchedule is the cron schedule for syncing user profiles from Zitadel.
 	// Default: "0 0 * * * *" (every hour)
 	ZitadelProfileSyncSchedule string
+
+	// SessionCleanupSchedule is the cron schedule for deleting ADK session data
+	// for old completed runs. Default: "0 0 3 * * *" (daily at 3am).
+	SessionCleanupSchedule string
+
+	// SessionRetentionDays is the minimum age (in days) of a completed run before
+	// its ADK session data (events, states, session rows) is deleted. Default: 90.
+	SessionRetentionDays int
 }
 
 // NewConfig creates a new Config from environment variables
@@ -65,6 +73,8 @@ func NewConfig() *Config {
 		StaleJobCleanupSchedule:      getEnvString("STALE_JOB_CLEANUP_SCHEDULE", ""),
 		DatabaseBackupSchedule:       getEnvString("DATABASE_BACKUP_SCHEDULE", "0 0 7 * * *"),
 		ZitadelProfileSyncSchedule:   getEnvString("ZITADEL_PROFILE_SYNC_SCHEDULE", "0 0 * * * *"),
+		SessionCleanupSchedule:       getEnvString("SESSION_CLEANUP_SCHEDULE", "0 0 3 * * *"),
+		SessionRetentionDays:         getEnvInt("SESSION_RETENTION_DAYS", 90),
 	}
 }
 

--- a/apps/server/domain/scheduler/module.go
+++ b/apps/server/domain/scheduler/module.go
@@ -106,6 +106,14 @@ func RegisterTasks(p TaskParams) error {
 			slog.String("error", err.Error()))
 	}
 
+	// Register session cleanup task (daily at 3am by default)
+	sessionCleanupTask := NewSessionCleanupTask(p.DB, p.Log, p.Cfg.SessionRetentionDays)
+	if err := addScheduledTask(p.Scheduler, p.Log, "session_cleanup",
+		p.Cfg.SessionCleanupSchedule, 24*time.Hour, sessionCleanupTask.Run); err != nil {
+		p.Log.Error("failed to register session cleanup task",
+			slog.String("error", err.Error()))
+	}
+
 	p.Log.Info("registered scheduled tasks",
 		slog.Any("tasks", p.Scheduler.ListTasks()))
 

--- a/apps/server/domain/scheduler/session_cleanup_task.go
+++ b/apps/server/domain/scheduler/session_cleanup_task.go
@@ -1,0 +1,120 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/emergent-company/emergent.memory/pkg/logger"
+)
+
+// SessionCleanupTask deletes ADK session data (events, states, sessions) for
+// agent runs that have been in a terminal state for longer than RetentionDays.
+//
+// Terminal run statuses: success, error, skipped, cancelled.
+//
+// Deletion order respects FK constraints:
+//  1. kb.adk_events   (FK → kb.adk_sessions ON DELETE CASCADE, but we delete explicitly for logging)
+//  2. kb.adk_states   (no FK, scoped by session_id)
+//  3. kb.adk_sessions (session_id == run_id by convention)
+//
+// The run record itself is NOT deleted — only the ADK session payload.
+type SessionCleanupTask struct {
+	db            *bun.DB
+	log           *slog.Logger
+	retentionDays int
+}
+
+// NewSessionCleanupTask creates a new SessionCleanupTask.
+// retentionDays is the minimum age (in days) of a completed run before its
+// session data is eligible for deletion. Defaults to 90 if <= 0.
+func NewSessionCleanupTask(db *bun.DB, log *slog.Logger, retentionDays int) *SessionCleanupTask {
+	if retentionDays <= 0 {
+		retentionDays = 90
+	}
+	return &SessionCleanupTask{
+		db:            db,
+		log:           log.With(logger.Scope("scheduler.session_cleanup")),
+		retentionDays: retentionDays,
+	}
+}
+
+// Run executes the session cleanup.
+func (t *SessionCleanupTask) Run(ctx context.Context) error {
+	start := time.Now()
+	cutoff := start.AddDate(0, 0, -t.retentionDays)
+
+	t.log.Debug("starting session cleanup",
+		slog.Int("retention_days", t.retentionDays),
+		slog.Time("cutoff", cutoff),
+	)
+
+	// Collect session IDs for runs that completed before the cutoff.
+	// session_id == run_id by ADK convention (set in executor.go buildSessionID).
+	var sessionIDs []string
+	err := t.db.NewSelect().
+		TableExpr("kb.agent_runs").
+		ColumnExpr("id::text").
+		Where("status IN ('success', 'error', 'skipped', 'cancelled')").
+		Where("completed_at IS NOT NULL").
+		Where("completed_at < ?", cutoff).
+		Scan(ctx, &sessionIDs)
+	if err != nil {
+		t.log.Error("session cleanup: failed to query eligible runs", slog.String("error", err.Error()))
+		return err
+	}
+
+	if len(sessionIDs) == 0 {
+		t.log.Debug("session cleanup: no sessions eligible for deletion",
+			slog.Duration("duration", time.Since(start)))
+		return nil
+	}
+
+	t.log.Info("session cleanup: found eligible sessions",
+		slog.Int("count", len(sessionIDs)),
+		slog.Time("cutoff", cutoff),
+	)
+
+	// Delete adk_events (cascade would handle this, but explicit for row count logging).
+	eventsDeleted, err := t.deleteWhere(ctx, "kb.adk_events", "session_id", sessionIDs)
+	if err != nil {
+		t.log.Warn("session cleanup: failed to delete adk_events", slog.String("error", err.Error()))
+		// best-effort: continue to attempt sessions/states deletion
+	}
+
+	// Delete adk_states scoped to these sessions.
+	statesDeleted, err := t.deleteWhere(ctx, "kb.adk_states", "session_id", sessionIDs)
+	if err != nil {
+		t.log.Warn("session cleanup: failed to delete adk_states", slog.String("error", err.Error()))
+	}
+
+	// Delete adk_sessions rows (id column).
+	sessionsDeleted, err := t.deleteWhere(ctx, "kb.adk_sessions", "id", sessionIDs)
+	if err != nil {
+		t.log.Warn("session cleanup: failed to delete adk_sessions", slog.String("error", err.Error()))
+	}
+
+	t.log.Info("session cleanup: completed",
+		slog.Int64("events_deleted", eventsDeleted),
+		slog.Int64("states_deleted", statesDeleted),
+		slog.Int64("sessions_deleted", sessionsDeleted),
+		slog.Duration("duration", time.Since(start)),
+	)
+
+	return nil
+}
+
+// deleteWhere deletes rows from table where column IN ids and returns the row count.
+func (t *SessionCleanupTask) deleteWhere(ctx context.Context, table, column string, ids []string) (int64, error) {
+	result, err := t.db.NewDelete().
+		TableExpr(table).
+		Where("? IN (?)", bun.Ident(column), bun.In(ids)).
+		Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return n, nil
+}


### PR DESCRIPTION
## What

Adds a scheduled `SessionCleanupTask` that prevents unbounded growth of ADK session tables by deleting old session data for completed runs.

## How it works

- Runs **daily at 3am** (cron: `0 0 3 * * *`)
- Finds all `kb.agent_runs` in terminal status (`success`, `error`, `skipped`, `cancelled`) with `completed_at` older than retention threshold
- Deletes `kb.adk_events`, `kb.adk_states`, and `kb.adk_sessions` rows for those runs (in that order, respecting FK constraints)
- **Run records are preserved** — only the ADK session payload is pruned
- Best-effort: warns on partial failures, never blocks the scheduler

## Configuration

| Env var | Default | Description |
|---|---|---|
| `SESSION_RETENTION_DAYS` | `90` | Days after completion before session data is deleted |
| `SESSION_CLEANUP_SCHEDULE` | `0 0 3 * * *` | Cron schedule (seconds precision) |

## Closes

Implements the session lifecycle pruning portion of #218. Cache-aware trimming deferred (see #218 comment).

## Summary by Sourcery

Add a scheduled task to periodically prune old ADK session data for completed agent runs based on configurable retention and schedule settings.

New Features:
- Introduce a SessionCleanupTask that deletes ADK session data for completed runs older than a configurable retention period.
- Add configuration options for session cleanup schedule and session retention days to the scheduler config.