### PR TITLE
fix: pass MCP relay tool definitions to LLM context during agent runs

### DIFF
--- a/apps/server/domain/agents/module.go
+++ b/apps/server/domain/agents/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/emergent-company/emergent.memory/domain/apitoken"
 	"github.com/emergent-company/emergent.memory/domain/events"
 	"github.com/emergent-company/emergent.memory/domain/mcp"
+	"github.com/emergent-company/emergent.memory/domain/mcprelay"
 	"github.com/emergent-company/emergent.memory/domain/mcpregistry"
 	"github.com/emergent-company/emergent.memory/domain/orgs"
 	"github.com/emergent-company/emergent.memory/domain/provider"
@@ -62,10 +63,11 @@ func provideWebhookRateLimiter() *WebhookRateLimiter {
 }
 
 // provideToolPool creates a ToolPool from fx dependencies.
-func provideToolPool(mcpService *mcp.Service, registryService *mcpregistry.Service, log *slog.Logger) *ToolPool {
+func provideToolPool(mcpService *mcp.Service, registryService *mcpregistry.Service, relayService *mcprelay.Service, log *slog.Logger) *ToolPool {
 	return NewToolPool(ToolPoolConfig{
 		MCPService:      mcpService,
 		RegistryService: registryService,
+		RelayService:    relayService,
 		Logger:          log,
 	})
 }

--- a/apps/server/domain/agents/toolpool.go
+++ b/apps/server/domain/agents/toolpool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -226,6 +227,7 @@ func (tp *ToolPool) buildCache(projectID string) *projectToolCache {
 	// 3. MCP Relay tools from connected relay instances
 	if tp.relayService != nil {
 		sessions := tp.relayService.ListByProject(projectID)
+		relayToolCount := 0
 		for _, sess := range sessions {
 			relayToolDefs, err := extractRelayToolDefs(sess.Tools)
 			if err != nil {
@@ -235,6 +237,7 @@ func (tp *ToolPool) buildCache(projectID string) *projectToolCache {
 				)
 				continue
 			}
+			relayToolCount += len(relayToolDefs)
 			for _, rt := range relayToolDefs {
 				// Prefix relay tool names: instanceID_toolname (same convention as external tools)
 				prefixedName := sess.InstanceID + "_" + rt.Name
@@ -247,12 +250,7 @@ func (tp *ToolPool) buildCache(projectID string) *projectToolCache {
 				cache.relayToolInstance[prefixedName] = sess.InstanceID
 			}
 		}
-		if len(sessions) > 0 {
-			relayToolCount := 0
-			for _, s := range sessions {
-				defs, _ := extractRelayToolDefs(s.Tools)
-				relayToolCount += len(defs)
-			}
+		if relayToolCount > 0 {
 			tp.log.Debug("loaded MCP relay tools into pool",
 				slog.String("project_id", projectID),
 				slog.Int("sessions", len(sessions)),
@@ -653,7 +651,11 @@ func (tp *ToolPool) wrapSingleTool(projectID string, td mcp.ToolDefinition) (too
 		pid := projectID
 		instID := instanceID
 		// Parse bare tool name by stripping the instanceID prefix and underscore
-		bareToolName := toolName[len(instID)+1:]
+		prefix := instID + "_"
+		if !strings.HasPrefix(toolName, prefix) {
+			return nil, fmt.Errorf("unexpected relay tool name %q for instance %q", toolName, instID)
+		}
+		bareToolName := strings.TrimPrefix(toolName, prefix)
 		return functiontool.New(
 			functiontool.Config{
 				Name:        toolName,
@@ -898,8 +900,15 @@ func convertRelayResponse(response map[string]any) (map[string]any, error) {
 	// Marshal result into ToolResult for convertToolResult
 	result := &mcp.ToolResult{}
 	data, err := json.Marshal(resultRaw)
-	if err == nil {
-		json.Unmarshal(data, result)
+	if err != nil {
+		return map[string]any{
+			"error": "invalid relay tool result: failed to marshal result",
+		}, nil
+	}
+	if err := json.Unmarshal(data, result); err != nil {
+		return map[string]any{
+			"error": "invalid relay tool result: failed to unmarshal into ToolResult",
+		}, nil
 	}
 
 	return convertToolResult(result)

--- a/apps/server/domain/agents/toolpool.go
+++ b/apps/server/domain/agents/toolpool.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/adk/tool/functiontool"
 
 	"github.com/emergent-company/emergent.memory/domain/mcp"
+	"github.com/emergent-company/emergent.memory/domain/mcprelay"
 	"github.com/emergent-company/emergent.memory/domain/mcpregistry"
 )
 
@@ -59,6 +60,7 @@ const DefaultMaxDepth = 6
 type ToolPoolConfig struct {
 	MCPService      *mcp.Service
 	RegistryService *mcpregistry.Service
+	RelayService    *mcprelay.Service
 	Logger          *slog.Logger
 }
 
@@ -68,6 +70,7 @@ type ToolPoolConfig struct {
 type ToolPool struct {
 	mcpService      *mcp.Service
 	registryService *mcpregistry.Service
+	relayService    *mcprelay.Service
 	log             *slog.Logger
 
 	// Per-project cache of tool definitions
@@ -83,6 +86,8 @@ type projectToolCache struct {
 	toolNames []string
 	// builtinTools tracks which tools came from builtin MCP service (not external servers)
 	builtinTools map[string]bool
+	// relayToolInstance maps prefixed tool name → instance ID for relay tool routing
+	relayToolInstance map[string]string
 }
 
 // NewToolPool creates a new ToolPool.
@@ -95,6 +100,7 @@ func NewToolPool(cfg ToolPoolConfig) *ToolPool {
 	return &ToolPool{
 		mcpService:      cfg.MCPService,
 		registryService: cfg.RegistryService,
+		relayService:    cfg.RelayService,
 		log:             log,
 		cache:           make(map[string]*projectToolCache),
 	}
@@ -128,8 +134,9 @@ func (tp *ToolPool) getOrBuildCache(projectID string) *projectToolCache {
 // buildCache creates the tool cache for a project by combining all tool sources.
 func (tp *ToolPool) buildCache(projectID string) *projectToolCache {
 	cache := &projectToolCache{
-		toolDefs:     make(map[string]mcp.ToolDefinition),
-		builtinTools: make(map[string]bool),
+		toolDefs:          make(map[string]mcp.ToolDefinition),
+		builtinTools:      make(map[string]bool),
+		relayToolInstance: make(map[string]string),
 	}
 
 	// 1. Built-in MCP tools — load from DB (respects per-project enabled flag).
@@ -213,6 +220,44 @@ func (tp *ToolPool) buildCache(projectID string) *projectToolCache {
 					slog.Int("count", len(extTools)),
 				)
 			}
+		}
+	}
+
+	// 3. MCP Relay tools from connected relay instances
+	if tp.relayService != nil {
+		sessions := tp.relayService.ListByProject(projectID)
+		for _, sess := range sessions {
+			relayToolDefs, err := extractRelayToolDefs(sess.Tools)
+			if err != nil {
+				tp.log.Warn("failed to extract relay tool definitions from session",
+					slog.String("instance_id", sess.InstanceID),
+					slog.String("error", err.Error()),
+				)
+				continue
+			}
+			for _, rt := range relayToolDefs {
+				// Prefix relay tool names: instanceID_toolname (same convention as external tools)
+				prefixedName := sess.InstanceID + "_" + rt.Name
+				cache.toolDefs[prefixedName] = mcp.ToolDefinition{
+					Name:        prefixedName,
+					Description: rt.Description,
+					InputSchema: rt.InputSchema,
+				}
+				cache.toolNames = append(cache.toolNames, prefixedName)
+				cache.relayToolInstance[prefixedName] = sess.InstanceID
+			}
+		}
+		if len(sessions) > 0 {
+			relayToolCount := 0
+			for _, s := range sessions {
+				defs, _ := extractRelayToolDefs(s.Tools)
+				relayToolCount += len(defs)
+			}
+			tp.log.Debug("loaded MCP relay tools into pool",
+				slog.String("project_id", projectID),
+				slog.Int("sessions", len(sessions)),
+				slog.Int("tools", relayToolCount),
+			)
 		}
 	}
 
@@ -588,6 +633,8 @@ func convertMCPSchemaToADK(input mcp.InputSchema) *jsonschema.Schema {
 // For external tools (prefixed with server name), it delegates to
 // mcpregistry.Service.CallExternalTool() which proxies through the
 // external MCP server connection.
+// For relay tools (prefixed with instance ID), it delegates to
+// mcprelay.Service.CallTool() which forwards through the WebSocket relay.
 func (tp *ToolPool) wrapSingleTool(projectID string, td mcp.ToolDefinition) (tool.Tool, error) {
 	// Capture for closure
 	toolName := td.Name
@@ -598,6 +645,30 @@ func (tp *ToolPool) wrapSingleTool(projectID string, td mcp.ToolDefinition) (too
 	// Check if this is a builtin tool by looking at the project cache
 	cache := tp.getOrBuildCache(projectID)
 	isBuiltin := cache.builtinTools[toolName]
+
+	// Check if this is a relay tool
+	if instanceID, ok := cache.relayToolInstance[toolName]; ok && tp.relayService != nil {
+		// Relay tool: forward through mcprelay.Service
+		relaySvc := tp.relayService
+		pid := projectID
+		instID := instanceID
+		// Parse bare tool name by stripping the instanceID prefix and underscore
+		bareToolName := toolName[len(instID)+1:]
+		return functiontool.New(
+			functiontool.Config{
+				Name:        toolName,
+				Description: td.Description,
+				InputSchema: inputSchema,
+			},
+			func(ctx tool.Context, args map[string]any) (map[string]any, error) {
+				result, err := relaySvc.CallTool(ctx, pid, instID, bareToolName, args)
+				if err != nil {
+					return map[string]any{"error": err.Error()}, nil
+				}
+				return convertRelayResponse(result)
+			},
+		)
+	}
 
 	if !isBuiltin && tp.registryService != nil {
 		// External tool: route through proxy
@@ -753,4 +824,83 @@ func (tp *ToolPool) wrapHiddenBuiltin(projectID, name, description string, schem
 		},
 	)
 	return t
+}
+
+// extractRelayToolDefs extracts MCP tool definitions from a relay session's tools/list
+// result map. The map is expected to have a "tools" key whose value is an array of
+// MCP tool objects, each with "name", "description", and "inputSchema" fields.
+func extractRelayToolDefs(toolsMap map[string]any) ([]mcp.ToolDefinition, error) {
+	toolsRaw, ok := toolsMap["tools"]
+	if !ok {
+		return nil, fmt.Errorf("tools/list result missing 'tools' key")
+	}
+	toolsArr, ok := toolsRaw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("tools value is not an array")
+	}
+
+	var defs []mcp.ToolDefinition
+	for _, tRaw := range toolsArr {
+		tMap, ok := tRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := tMap["name"].(string)
+		if name == "" {
+			continue
+		}
+		desc, _ := tMap["description"].(string)
+
+		var inputSchema mcp.InputSchema
+		if is, ok := tMap["inputSchema"]; ok {
+			data, err := json.Marshal(is)
+			if err == nil {
+				json.Unmarshal(data, &inputSchema)
+			}
+		}
+		if inputSchema.Type == "" {
+			inputSchema.Type = "object"
+		}
+
+		defs = append(defs, mcp.ToolDefinition{
+			Name:        name,
+			Description: desc,
+			InputSchema: inputSchema,
+		})
+	}
+
+	return defs, nil
+}
+
+// convertRelayResponse converts a raw MCP JSON-RPC response map from a relay tool
+// call into a format compatible with convertToolResult.
+// The response map is expected to have a "result" key (on success) or "error" key
+// (on failure), following the JSON-RPC 2.0 specification.
+func convertRelayResponse(response map[string]any) (map[string]any, error) {
+	// Check for JSON-RPC error
+	if errRaw, ok := response["error"]; ok {
+		errMap, ok := errRaw.(map[string]any)
+		if ok {
+			msg, _ := errMap["message"].(string)
+			if msg != "" {
+				return map[string]any{"error": msg}, nil
+			}
+		}
+		return map[string]any{"error": "relay tool returned an error"}, nil
+	}
+
+	// Extract result field from JSON-RPC response
+	resultRaw, ok := response["result"]
+	if !ok {
+		return map[string]any{"result": "ok"}, nil
+	}
+
+	// Marshal result into ToolResult for convertToolResult
+	result := &mcp.ToolResult{}
+	data, err := json.Marshal(resultRaw)
+	if err == nil {
+		json.Unmarshal(data, result)
+	}
+
+	return convertToolResult(result)
 }

--- a/apps/server/domain/mcprelay/service.go
+++ b/apps/server/domain/mcprelay/service.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
 
@@ -259,4 +260,27 @@ func (s *Service) ListByProject(projectID string) []*Session {
 		}
 	}
 	return out
+}
+
+// CallTool forwards an MCP tool call to a connected relay instance.
+// The instanceID is the bare instance ID; the toolName is the bare MCP tool name
+// (without any prefix). Returns the raw MCP tool result as a map.
+func (s *Service) CallTool(ctx context.Context, projectID, instanceID, toolName string, args map[string]any) (map[string]any, error) {
+	sess, ok := s.Get(projectID, instanceID)
+	if !ok {
+		return nil, fmt.Errorf("relay instance %q not found or disconnected", instanceID)
+	}
+
+	reqID := uuid.New().String()
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      reqID,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+
+	return sess.SendRequest(ctx, reqID, payload)
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -463,10 +463,8 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/tchap/go-patricia v2.2.6+incompatible h1:JvoDL7JSoIP2HDE8AbDH3zC8QBPxmzYe32HHy5yQ+Ck=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
@@ -545,6 +543,7 @@ golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
@@ -563,6 +562,7 @@ google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8 h1:Cpp2P6TPjujNoC5M2K
 google.golang.org/genproto v0.0.0-20251014184007-4626949a642f/go.mod h1:PI3KrSadr00yqfv6UDvgZGFsmLqeRIwt8x4p5Oo7CdM=
 google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 h1:VQZ/yAbAtjkHgH80teYd2em3xtIkkHd7ZhqfH2N9CsM=
 google.golang.org/genproto v0.0.0-20260128011058-8636f8732409/go.mod h1:rxKD3IEILWEu3P44seeNOAwZN4SaoKaQ/2eTg4mM6EM=
+google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d h1:vsOm753cOAMkt76efriTCDKjpCbK18XGHMJHo0JUKhc=
 google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f h1:OiFuztEyBivVKDvguQJYWq1yDcfAHIID/FVrPR4oiI0=
 google.golang.org/genproto/googleapis/api v0.0.0-20251014184007-4626949a642f/go.mod h1:kprOiu9Tr0JYyD6DORrc4Hfyk3RFXqkQ3ctHEum3ZbM=
 google.golang.org/genproto/googleapis/api v0.0.0-20251029180050-ab9386a59fda/go.mod h1:fDMmzKV90WSg1NbozdqrE64fkuTv6mlq2zxo9ad+3yo=


### PR DESCRIPTION
## Summary

Fixes #221 — MCP relay tools registered via WebSocket were never surfaced to the LLM during agent execution. The agent runtime's `ToolPool` only loaded built-in tools and external MCP server tools; relay-registered tools were stored in the in-memory session registry but invisible to the LLM.

## Root Cause

`ToolPool.buildCache()` had two tool sources (built-in MCP tools + external MCP server tools) but zero awareness of the relay session registry managed by `mcprelay.Service`. When building the LLM's tool configuration, relay tools were simply never included.

## Changes

### `mcprelay/service.go`
- Added `CallTool(ctx, projectID, instanceID, toolName, args)` method to `Service` — forwards MCP `tools/call` requests to a connected relay instance via its WebSocket session

### `agents/toolpool.go`
- Added `RelayService` field to `ToolPoolConfig` and `ToolPool`
- Added `relayToolInstance` map to `projectToolCache` — tracks which prefixed tool names belong to which relay instance
- **`buildCache()`**: Added section 3 to iterate `relayService.ListByProject()`, parse each session's `tools/list` result, and add tools with `{instanceID}_{bareToolName}` prefix (same convention as external MCP server tools)
- **`wrapSingleTool()`**: Added relay-aware routing — when a tool is in `relayToolInstance`, the ADK closure routes through `relaySvc.CallTool()` instead of the MCP or registry service
- Added `extractRelayToolDefs()` — parses `map[string]any` tool definitions from the relay session into typed `mcp.ToolDefinition` structs
- Added `convertRelayResponse()` — handles JSON-RPC response/error structure from relay tool calls, converts to the format expected by `convertToolResult`

### `agents/module.go`
- Wired `*mcprelay.Service` into `provideToolPool()` via fx dependency injection

## Agent Definition Compatibility

Agent definitions reference relay tools with the same `{instanceID}_{bareName}` prefix convention already accepted by the agent definition validation. No schema changes needed.

## Test Plan

- [x] Both changed packages compile cleanly
- [x] Full `go build ./...` passes
- [x] Relay tool definitions are now loaded into ToolPool cache
- [x] Relay tool calls route through `mcprelay.Service.CallTool()` (not MCP/registry)

## Summary by Sourcery

Surface MCP relay-registered tools to the agent tool pool so they are available and invocable during LLM agent runs.

Bug Fixes:
- Ensure MCP relay tools registered over WebSocket are included in the per-project tool cache and exposed to the LLM.
- Route relay tool invocations through the MCP relay service rather than treating them as builtin or external registry tools.

Enhancements:
- Extend the tool pool to track relay tool ownership by instance and to parse relay tool definitions from session metadata.
- Wire the MCP relay service into the agents module via dependency injection so relay tools participate in normal agent tooling.