### PR TITLE
ci: auto-create release tag when VERSION changes on main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,58 @@
+name: Auto-Tag on Version Bump
+
+on:
+  push:
+    branches: [main]
+    paths: ['VERSION']
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read VERSION
+        id: version
+        run: |
+          VERSION=$(cat VERSION | tr -d ' \n\r')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Read version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if gh release view "$TAG" --repo ${{ github.repository }} > /dev/null 2>&1; then
+            echo "Tag $TAG already exists as a release — skipping"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          elif git tag -l "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists locally — skipping"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG does not exist — will create"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure git
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "emergent-bot"
+          git config user.email "bot@emergent-company.ai"
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Created and pushed tag: $TAG"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -18,12 +18,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify GitHub CLI
+        run: |
+          if ! command -v gh &>/dev/null; then
+            echo "ERROR: gh CLI is not installed on the runner." >&2
+            exit 1
+          fi
+          echo "gh version: $(gh --version | head -1)"
+
       - name: Read VERSION
         id: version
         run: |
-          VERSION=$(cat VERSION | tr -d ' \n\r')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          VERSION=$(tr -d ' \n\r' < VERSION)
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: VERSION file is empty or contains only whitespace." >&2
+            exit 1
+          fi
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){2}$'; then
+            echo "ERROR: VERSION '$VERSION' is not a valid semver (expected MAJOR.MINOR.PATCH, e.g. 1.2.3)." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Read version: $VERSION"
 
       - name: Check if tag already exists
@@ -46,8 +63,8 @@ jobs:
       - name: Configure git
         if: steps.check.outputs.exists == 'false'
         run: |
-          git config user.name "emergent-bot"
-          git config user.email "bot@emergent-company.ai"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Create and push tag
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-creates a v{VERSION} tag when the VERSION file changes on main (when a version-bump PR merges).

## How it works

1. Version-bump PR merges -> VERSION file changes on main
2. This workflow triggers, reads the new version, creates tag v{VERSION}
3. Tag push triggers publish-self-hosted-images.yml -> Docker build + push to GHCR
4. Tag push also triggers cli.yml -> CLI build + GitHub Release creation
5. Deploy workflow in infra repo can optionally auto-trigger on the new release

## Details

- Only triggers on push to main with changes to VERSION
- Checks if the tag already exists before creating (idempotent)
- Creates an annotated tag matching the version in the VERSION file
- Uses secrets.GITHUB_TOKEN (no additional secrets needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release tagging workflow that creates and pushes release tags when version numbers are updated on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->