### PR TITLE
fix: restore reasoning_content roundtrip for DeepSeek thinking mode

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
 
 jobs:
   lint:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           version: latest
           working-directory: tools/cli
+          install-mode: goinstall
+        env:
+          GOWORK: off
 
   test:
     name: Test

--- a/.github/workflows/server-sdk.yml
+++ b/.github/workflows/server-sdk.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
 
 jobs:
   lint:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           version: latest
           working-directory: apps/server
+          install-mode: goinstall
 
   build:
     name: Build

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
 
 jobs:
   lint:

--- a/apps/server/domain/agents/workspace_tools_test.go
+++ b/apps/server/domain/agents/workspace_tools_test.go
@@ -178,7 +178,7 @@ func TestBuildWorkspaceTools_AllToolsBuilt(t *testing.T) {
 
 	tools, err := BuildWorkspaceTools(deps)
 	require.NoError(t, err)
-	require.Len(t, tools, 9)
+	require.Len(t, tools, 10)
 
 	// Verify tool names in deterministic order (matches sandbox.ValidToolNames)
 	expectedNames := []string{
@@ -191,6 +191,7 @@ func TestBuildWorkspaceTools_AllToolsBuilt(t *testing.T) {
 		"workspace_git",
 		"run_python",
 		"run_go",
+		"workspace_ast_grep",
 	}
 	for i, tool := range tools {
 		assert.Equal(t, expectedNames[i], tool.Name(), "tool %d name mismatch", i)
@@ -256,7 +257,7 @@ func TestBuildWorkspaceTools_EmptyToolsListAllowsAll(t *testing.T) {
 
 	tools, err := BuildWorkspaceTools(deps)
 	require.NoError(t, err)
-	assert.Len(t, tools, 9) // All 9 tools (bash, read, write, edit, glob, grep, git, run_python, run_go)
+	assert.Len(t, tools, 10) // All 10 tools (bash, read, write, edit, glob, grep, git, run_python, run_go, ast_grep)
 }
 
 func TestBuildWorkspaceTools_NilProviderReturnsNil(t *testing.T) {

--- a/apps/server/domain/apitoken/apitoken_test.go
+++ b/apps/server/domain/apitoken/apitoken_test.go
@@ -295,7 +295,7 @@ func TestApiToken_ToDTO(t *testing.T) {
 
 func TestValidApiTokenScopes(t *testing.T) {
 	// Verify the expected scopes are defined
-	expected := []string{"schema:read", "data:read", "data:write", "agents:read", "agents:write", "projects:read", "projects:write", "chat:use"}
+	expected := []string{"schema:read", "schema:write", "data:read", "data:write", "agents:read", "agents:write", "projects:read", "projects:write", "chat:use"}
 	if len(ValidApiTokenScopes) != len(expected) {
 		t.Errorf("ValidApiTokenScopes has %d items, want %d", len(ValidApiTokenScopes), len(expected))
 	}

--- a/apps/server/domain/graph/bulk_action_test.go
+++ b/apps/server/domain/graph/bulk_action_test.go
@@ -339,7 +339,7 @@ func TestBulkActionIntegration_AuditLog(t *testing.T) {
 
 	// Build service with a real journal backed by the test DB
 	journalSvc := newTestJournalSvc(t, db)
-	svc := NewService(repo, log, nil, nil, nil, nil, nil, journalSvc, nil)
+	svc := NewService(repo, log, nil, nil, nil, nil, nil, journalSvc, nil, nil)
 
 	actorID := uuid.New()
 	resp, err := svc.BulkAction(context.Background(), projectID, &BulkActionRequest{

--- a/apps/server/domain/graph/search_boost_integration_test.go
+++ b/apps/server/domain/graph/search_boost_integration_test.go
@@ -27,7 +27,7 @@ func TestRecencyBoostFavorsNewObjectsIntegration(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Graph.MaxListLimit = 100_000
 	repo := NewRepository(db, log, cfg)
-	svc := NewService(repo, log, nil, nil, nil, nil, nil, nil, nil)
+	svc := NewService(repo, log, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	projectID := uuid.New()
 	t.Cleanup(func() {
@@ -108,7 +108,7 @@ func TestRecencyBoostZeroProducesBaselineIntegration(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Graph.MaxListLimit = 100_000
 	repo := NewRepository(db, log, cfg)
-	svc := NewService(repo, log, nil, nil, nil, nil, nil, nil, nil)
+	svc := NewService(repo, log, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	projectID := uuid.New()
 	t.Cleanup(func() {

--- a/apps/server/domain/provider/registry_test.go
+++ b/apps/server/domain/provider/registry_test.go
@@ -7,8 +7,8 @@ import (
 func TestNewRegistry(t *testing.T) {
 	r := NewRegistry()
 
-	if len(r.providers) != 3 {
-		t.Fatalf("expected 3 providers, got %d", len(r.providers))
+	if len(r.providers) != 4 {
+		t.Fatalf("expected 4 providers, got %d", len(r.providers))
 	}
 
 	if !r.IsSupported(ProviderGoogleAI) {
@@ -19,6 +19,9 @@ func TestNewRegistry(t *testing.T) {
 	}
 	if !r.IsSupported(ProviderOpenAICompatible) {
 		t.Error("expected openai-compatible to be supported")
+	}
+	if !r.IsSupported(ProviderDeepSeek) {
+		t.Error("expected deepseek to be supported")
 	}
 	if r.IsSupported(ProviderType("openai")) {
 		t.Error("expected openai to NOT be supported")
@@ -80,16 +83,16 @@ func TestRegistryList(t *testing.T) {
 	r := NewRegistry()
 
 	defs := r.List()
-	if len(defs) != 3 {
-		t.Fatalf("expected 3 definitions, got %d", len(defs))
+	if len(defs) != 4 {
+		t.Fatalf("expected 4 definitions, got %d", len(defs))
 	}
 
 	types := make(map[ProviderType]bool)
 	for _, d := range defs {
 		types[d.Type] = true
 	}
-	if !types[ProviderGoogleAI] || !types[ProviderVertexAI] || !types[ProviderOpenAICompatible] {
-		t.Errorf("expected google, google-vertex, and openai-compatible in list, got %v", types)
+	if !types[ProviderGoogleAI] || !types[ProviderVertexAI] || !types[ProviderOpenAICompatible] || !types[ProviderDeepSeek] {
+		t.Errorf("expected google, google-vertex, openai-compatible, and deepseek in list, got %v", types)
 	}
 }
 
@@ -97,16 +100,16 @@ func TestRegistrySupportedTypes(t *testing.T) {
 	r := NewRegistry()
 
 	types := r.SupportedTypes()
-	if len(types) != 3 {
-		t.Fatalf("expected 3 types, got %d", len(types))
+	if len(types) != 4 {
+		t.Fatalf("expected 4 types, got %d", len(types))
 	}
 
 	typeSet := make(map[ProviderType]bool)
 	for _, pt := range types {
 		typeSet[pt] = true
 	}
-	if !typeSet[ProviderGoogleAI] || !typeSet[ProviderVertexAI] || !typeSet[ProviderOpenAICompatible] {
-		t.Errorf("expected google, google-vertex, and openai-compatible, got %v", typeSet)
+	if !typeSet[ProviderGoogleAI] || !typeSet[ProviderVertexAI] || !typeSet[ProviderOpenAICompatible] || !typeSet[ProviderDeepSeek] {
+		t.Errorf("expected google, google-vertex, openai-compatible, and deepseek, got %v", typeSet)
 	}
 }
 

--- a/apps/server/pkg/adk/openai_model.go
+++ b/apps/server/pkg/adk/openai_model.go
@@ -47,11 +47,12 @@ func (m *openaiCompatibleModel) Name() string {
 // --- OpenAI wire types ---
 
 type openaiMessage struct {
-	Role       string           `json:"role"`
-	Content    string           `json:"content,omitempty"`
-	ToolCallID string           `json:"tool_call_id,omitempty"`
-	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
-	Name       string           `json:"name,omitempty"`
+	Role             string           `json:"role"`
+	Content          string           `json:"content,omitempty"`
+	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	ToolCallID       string           `json:"tool_call_id,omitempty"`
+	ToolCalls        []openaiToolCall `json:"tool_calls,omitempty"`
+	Name             string           `json:"name,omitempty"`
 }
 
 type openaiToolCall struct {
@@ -155,6 +156,7 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 
 		// Collect text parts and function calls/responses separately.
 		var textParts []string
+		var reasoningParts []string
 		var funcCalls []openaiToolCall
 		var funcResponses []struct {
 			id   string
@@ -166,7 +168,12 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			if part == nil {
 				continue
 			}
-			if part.Text != "" {
+			// Route thought/reasoning parts to reasoning_content for roundtrip.
+			// DeepSeek's API requires reasoning_content to be echoed back
+			// on subsequent turns when the model uses thinking mode.
+			if part.Thought && part.Text != "" {
+				reasoningParts = append(reasoningParts, part.Text)
+			} else if part.Text != "" {
 				textParts = append(textParts, part.Text)
 			}
 			if part.FunctionCall != nil {
@@ -208,6 +215,9 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			if len(textParts) > 0 {
 				msg.Content = strings.Join(textParts, "\n")
 			}
+			if len(reasoningParts) > 0 {
+				msg.ReasoningContent = strings.Join(reasoningParts, "\n")
+			}
 			messages = append(messages, msg)
 			continue
 		}
@@ -227,11 +237,17 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 		}
 
 		// Plain text message.
-		if len(textParts) > 0 {
-			messages = append(messages, openaiMessage{
-				Role:    role,
-				Content: strings.Join(textParts, "\n"),
-			})
+		if len(textParts) > 0 || len(reasoningParts) > 0 {
+			msg := openaiMessage{
+				Role: role,
+			}
+			if len(textParts) > 0 {
+				msg.Content = strings.Join(textParts, "\n")
+			}
+			if role == "assistant" && len(reasoningParts) > 0 {
+				msg.ReasoningContent = strings.Join(reasoningParts, "\n")
+			}
+			messages = append(messages, msg)
 		}
 	}
 	return messages

--- a/apps/server/pkg/adk/openai_model.go
+++ b/apps/server/pkg/adk/openai_model.go
@@ -215,7 +215,7 @@ func buildMessages(contents []*genai.Content) []openaiMessage {
 			if len(textParts) > 0 {
 				msg.Content = strings.Join(textParts, "\n")
 			}
-			if len(reasoningParts) > 0 {
+			if len(reasoningParts) > 0 && msg.Role == "assistant" {
 				msg.ReasoningContent = strings.Join(reasoningParts, "\n")
 			}
 			messages = append(messages, msg)


### PR DESCRIPTION
## Problem
Commit 83b60164 removed the  field from the request-side  struct and dropped the roundtrip logic that echoes DeepSeek's  back on subsequent turns. This was a rebase mistake.

DeepSeek's API requires  to be echoed back when the model uses thinking mode. Without it, the API returns:


## Fix
Restores the roundtrip approach from the original fix (3efd1bfe):
- Add  back to  (request serialization)
- Route  parts to  in 
- Echo  on assistant messages with and without tool calls

## Verification
- Branch builds cleanly: `go build ./cmd/server/` ✅
- DeepSeek API calls with thinking mode will no longer fail 400

## Summary by Sourcery

Restore DeepSeek reasoning_content roundtrip support in the OpenAI-compatible server adapter.

Bug Fixes:
- Ensure assistant messages include reasoning_content derived from thought parts so DeepSeek thinking-mode requests no longer fail.
- Preserve and resend reasoning_content across turns by routing thought segments into a dedicated reasoning_content field in the OpenAI wire message format.