### PR TITLE
feat: graceful message when relay tools are called on disconnected session

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -73,3 +73,14 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
           echo "Created and pushed tag: $TAG"
+
+      - name: Trigger release workflows
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "Triggering release workflows on $TAG..."
+          gh workflow run "Memory CLI & Release" --ref "$TAG" --repo ${{ github.repository }}
+          gh workflow run "Publish Self-Hosted Images" --ref "$TAG" --repo ${{ github.repository }}
+          echo "Workflows dispatched on tag: $TAG"

--- a/apps/server/domain/agents/toolpool.go
+++ b/apps/server/domain/agents/toolpool.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path"
@@ -665,6 +666,16 @@ func (tp *ToolPool) wrapSingleTool(projectID string, td mcp.ToolDefinition) (too
 			func(ctx tool.Context, args map[string]any) (map[string]any, error) {
 				result, err := relaySvc.CallTool(ctx, pid, instID, bareToolName, args)
 				if err != nil {
+					if errors.Is(err, mcprelay.ErrSessionNotFound) {
+						return map[string]any{
+							"error": fmt.Sprintf(
+								"Tool %q is provided by a connected client (%s) that is currently offline. "+
+									"The client may have disconnected (e.g. laptop went to sleep, network dropped). "+
+									"Please try again later when the device reconnects.",
+								toolName, instID,
+							),
+						}, nil
+					}
 					return map[string]any{"error": err.Error()}, nil
 				}
 				return convertRelayResponse(result)

--- a/apps/server/domain/mcprelay/service.go
+++ b/apps/server/domain/mcprelay/service.go
@@ -16,6 +16,7 @@ package mcprelay
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -24,6 +25,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
+
+// ErrSessionNotFound is returned when a relay session is not in the active set.
+// The relay was connected at some point (so tools were registered) but is currently
+// disconnected (e.g. laptop went to sleep, network dropped). Callers handling this
+// error should return a user-friendly message suggesting retry later.
+var ErrSessionNotFound = errors.New("relay session not found or disconnected")
 
 // -----------------------------------------------------------------------------
 // Wire protocol frames
@@ -268,7 +275,7 @@ func (s *Service) ListByProject(projectID string) []*Session {
 func (s *Service) CallTool(ctx context.Context, projectID, instanceID, toolName string, args map[string]any) (map[string]any, error) {
 	sess, ok := s.Get(projectID, instanceID)
 	if !ok {
-		return nil, fmt.Errorf("relay instance %q not found or disconnected", instanceID)
+		return nil, fmt.Errorf("%w: instance %q", ErrSessionNotFound, instanceID)
 	}
 
 	reqID := uuid.New().String()


### PR DESCRIPTION
## Summary

When a relay session disconnects (e.g. laptop goes to sleep, network drops), tools from that session remain visible to the agent — since disconnection is often temporary, removing them would cause unnecessary churn.

Previously, calling a disconnected relay tool returned a raw internal error (`relay instance X not found or disconnected`), which was confusing to the LLM agent.

Now it returns a clear, actionable message explaining the tool is hosted by a connected client that is currently offline, and suggests retrying later.

## Changes

- **mcprelay/service.go**: Added exported `ErrSessionNotFound` sentinel error for clean consumer-side detection
- **agents/toolpool.go**: Relay tool call closure now checks for `errors.Is(err, mcprelay.ErrSessionNotFound)` and returns a user-friendly message instead of the raw error

## Example agent response after fix

> "Tool airmcp_notes is provided by a connected client (mcj-mini-slave) that is currently offline. The client may have disconnected (e.g. laptop went to sleep, network dropped). Please try again later when the device reconnects."

## Testing

- Build verified via `go build ./...`
- Sentinel error properly wraps original: `fmt.Errorf("%w: instance %q", ErrSessionNotFound, instanceID)` so consumers can use both `errors.Is()` and formatted detail

## Summary by Sourcery

Improve handling of disconnected relay sessions by surfacing a clear offline-tool message to agents and wiring CI tagging to automatically trigger downstream release workflows.

New Features:
- Return a user-friendly error message when calling tools from relay sessions that have gone offline

Enhancements:
- Introduce a reusable ErrSessionNotFound sentinel error in the relay service for clean detection of disconnected sessions

CI:
- Extend the auto-tag workflow to dispatch release and image publishing workflows after creating a new tag